### PR TITLE
prefix enums with type name to prevent cross schema collisions

### DIFF
--- a/test/alias-fixed/union.avsc
+++ b/test/alias-fixed/union.avsc
@@ -16,7 +16,6 @@
           {
               "name": "id",
               "type": "string",
-              "logicalType": "uuid",
               "doc": "Unique ID for this event."
           },
           {

--- a/test/enum/schema_test.go
+++ b/test/enum/schema_test.go
@@ -85,5 +85,5 @@ func TestRoundTrip(t *testing.T) {
 
 func TestDefaults(t *testing.T) {
 	record := NewEnumTestRecord()
-	assert.Equal(t, record.EnumField, TestSymbol3)
+	assert.Equal(t, record.EnumField, TestEnumTypeTestSymbol3)
 }

--- a/test/union-root-short/union.avsc
+++ b/test/union-root-short/union.avsc
@@ -20,7 +20,6 @@
           {
               "name": "id",
               "type": "string",
-              "logicalType": "uuid",
               "doc": "Unique ID for this event.",
               "metadata": {
                 "key": "field1"

--- a/test/union-root/union.avsc
+++ b/test/union-root/union.avsc
@@ -20,7 +20,6 @@
           {
               "name": "id",
               "type": "string",
-              "logicalType": "uuid",
               "doc": "Unique ID for this event.",
               "metadata": {
                 "key": "field1"

--- a/types/enum.go
+++ b/types/enum.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"github.com/actgardner/gogen-avro/generator"
+	"strings"
 )
 
 const enumTypeDef = `
@@ -18,7 +19,7 @@ func (e %v) String() string {
 	switch e {
 %v
 	}
-	return "Unknown"
+	return "unknown"
 }
 `
 
@@ -70,7 +71,7 @@ func (e *EnumDefinition) GoType() string {
 func (e *EnumDefinition) typeList() string {
 	typeStr := ""
 	for i, t := range e.symbols {
-		typeStr += fmt.Sprintf("%v %v = %v\n", generator.ToPublicName(t), e.GoType(), i)
+		typeStr += fmt.Sprintf("%v %v = %v\n", generator.ToPublicName(e.GoType()+strings.Title(t)), e.GoType(), i)
 	}
 	return typeStr
 }
@@ -78,7 +79,7 @@ func (e *EnumDefinition) typeList() string {
 func (e *EnumDefinition) stringerList() string {
 	stringerStr := ""
 	for _, t := range e.symbols {
-		stringerStr += fmt.Sprintf("case %v:\n return %q\n", generator.ToPublicName(t), t)
+		stringerStr += fmt.Sprintf("case %v:\n return %q\n", generator.ToPublicName(e.GoType()+strings.Title(t)), t)
 	}
 	return stringerStr
 }
@@ -147,5 +148,5 @@ func (s *EnumDefinition) DefaultValue(lvalue string, rvalue interface{}) (string
 		return "", fmt.Errorf("Expected string as default for field %v, got %q", lvalue, rvalue)
 	}
 
-	return fmt.Sprintf("%v = %v", lvalue, generator.ToPublicName(rvalue.(string))), nil
+	return fmt.Sprintf("%v = %v", lvalue, generator.ToPublicName(s.GoType()+strings.Title(rvalue.(string)))), nil
 }


### PR DESCRIPTION
If multiple Avro schemas have enums with at least one intersecting enum value, the generator isn't aware of that and generates code that does not compile. 
This pull request solves the issue in a way that prefixes the constant's name with the name of its type.