### PR TITLE
Support Schema with Empty Recod

### DIFF
--- a/types/record.go
+++ b/types/record.go
@@ -3,8 +3,9 @@ package types
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/actgardner/gogen-avro/generator"
 	"strconv"
+
+	"github.com/actgardner/gogen-avro/generator"
 )
 
 const recordStructDefTemplate = `
@@ -103,6 +104,10 @@ func (r *RecordDefinition) structFields() string {
 }
 
 func (r *RecordDefinition) fieldSerializers() string {
+	if len(r.fields) == 0 {
+		//in case the record has no fields just return empty fieldSerializers
+		return ""
+	}
 	serializerMethods := "var err error\n"
 	for _, f := range r.fields {
 		serializerMethods += fmt.Sprintf("err = %v(r.%v, w)\nif err != nil {return err}\n", f.Type().SerializerMethod(), f.GoName())

--- a/types/record.go
+++ b/types/record.go
@@ -39,7 +39,6 @@ func (r %v) Serialize(w io.Writer) error {
 const recordStructDeserializerTemplate = `
 func %v(r io.Reader) (%v, error) {
 	var str = &%v{}
-	var err error
 	%v
 	return str, nil
 }
@@ -104,7 +103,7 @@ func (r *RecordDefinition) structFields() string {
 }
 
 func (r *RecordDefinition) fieldSerializers() string {
-	if len(r.fields) == 0 {
+	if r.fields == nil || len(r.fields) == 0 {
 		//in case the record has no fields just return empty fieldSerializers
 		return ""
 	}
@@ -116,7 +115,11 @@ func (r *RecordDefinition) fieldSerializers() string {
 }
 
 func (r *RecordDefinition) fieldDeserializers() string {
-	deserializerMethods := ""
+	if r.fields == nil || len(r.fields) == 0 {
+		//in case the record has no fields just assign err to nil to work with template defining var err error
+		return ""
+	}
+	deserializerMethods := "var err error\n"
 	for _, f := range r.fields {
 		deserializerMethods += fmt.Sprintf("str.%v, err = %v(r)\nif err != nil {return nil, err}\n", f.GoName(), f.Type().DeserializerMethod())
 	}


### PR DESCRIPTION
I am just trying to port a scala demo to golang. As Scala is also supporting OO sometimes records are just as types to identify an action. In this case the class may have no members which may create schema with record not having any fields.

This is supported by the AVRO specification or at least is allows it. I do not see a reason why the generator should not just gracefully create empty serializers and deserialiers.