### PR TITLE
[WIP] Extend namespace support to struct names

### DIFF
--- a/generator/util.go
+++ b/generator/util.go
@@ -7,8 +7,9 @@ import (
 
 // ToPublicName returns a go-idiomatic public name. The Avro spec specifies names must start with [A-Za-z_] and contain [A-Za-z0-9_].
 // The golang spec says valid identifiers start with [A-Za-z_] and contain [A-Za-z0-9], but the first character must be [A-Z] for the field to be public.
+// Additional treatment is applied to the name, in order to remove possible "." from it.
 func ToPublicName(name string) string {
-	return strings.Title(strings.Trim(name, "_"))
+	return strings.Title(strings.Trim(strings.Replace(name, ".", "_", -1), "_"))
 }
 
 // ToSnake makes filenames snake-case, taken from https://gist.github.com/elwinar/14e1e897fdbe4d3432e1

--- a/types/record.go
+++ b/types/record.go
@@ -80,7 +80,7 @@ func (r *RecordDefinition) AvroName() QualifiedName {
 }
 
 func (r *RecordDefinition) Name() string {
-	return generator.ToPublicName(r.name.Name)
+	return generator.ToPublicName(r.name.String())
 }
 
 func (r *RecordDefinition) GoType() string {

--- a/types/schema.go
+++ b/types/schema.go
@@ -87,9 +87,13 @@ func (n *Namespace) RegisterDefinition(d Definition) error {
 func ParseAvroName(enclosing, name string) QualifiedName {
 	lastIndex := strings.LastIndex(name, ".")
 	if lastIndex != -1 {
-		return QualifiedName{name[:lastIndex], name[lastIndex+1:]}
+		if enclosing == "" {
+			enclosing = name[:lastIndex]
+		} else {
+			enclosing = enclosing + "." + name[:lastIndex]
+		}
 	}
-	return QualifiedName{enclosing, name}
+	return QualifiedName{enclosing, name[lastIndex+1:]}
 }
 
 // TypeForSchema accepts an Avro schema as a JSON string, decode it and return the AvroType defined at the top level:


### PR DESCRIPTION
This commit makes the generator to use the namespace as part of file/struct name, in order to avoid clashes in the generated source. The following AVRO schema is an example of a working testcase:

```
{
  "type": "record",
  "name": "RecordExample",
  "fields": [{
    "name": "namespacedField1",
    "type": {
      "type": "array",
      "items": {
        "type": "record",
        "name": "Pair",
        "namespace": "avro.test.namevaluepair",
        "fields": [{
          "name": "name",
          "type": {
            "type": "string",
            "avro.java.string": "String"
          }
        }, {
          "name": "value",
          "type": {
            "type": "string",
            "avro.java.string": "String"
          }
        }]
      }
    }
  }, {
    "name": "namespacedField2",
    "type": {
      "type": "array",
      "items": {
        "type": "record",
        "name": "Pair",
        "namespace": "avro.test.keyvaluepair",
        "fields": [{
          "name": "key",
          "type": {
            "type": "string",
            "avro.java.string": "String"
          }
        }, {
          "name": "value",
          "type": {
            "type": "string",
            "avro.java.string": "String"
          }
        }]
      }
    }
  }]
}
```