### PR TITLE
Don't break after returning in a generated Union method

### DIFF
--- a/schema/union.go
+++ b/schema/union.go
@@ -121,11 +121,10 @@ func (s *UnionField) FieldsMethodDef() string {
 			getBody += fmt.Sprintf("r.%v = %v\n", f.Name(), constructor.ConstructorMethod())
 		}
 		if f.WrapperType() == "" {
-			getBody += fmt.Sprintf("return r.%v", f.Name())
+			getBody += fmt.Sprintf("return r.%v\n", f.Name())
 		} else {
-			getBody += fmt.Sprintf("return (*%v)(&r.%v)", f.WrapperType(), f.Name())
+			getBody += fmt.Sprintf("return (*%v)(&r.%v)\n", f.WrapperType(), f.Name())
 		}
-		getBody += "\nbreak\n"
 	}
 	return fmt.Sprintf(unionFieldTemplate, s.GoType(), s.unionEnumType(), getBody)
 }


### PR DESCRIPTION
To prevent an 'unreachable code' error with go vet, we should avoid breaking after a return in a switch case as defined in schema/union.go. This has no observable effect on the code and is simply a fix to get the generated go files to pass static analysis.