### PR TITLE
Generate code to allow clients to use a different schema when deserializing

### DIFF
--- a/schema/record.go
+++ b/schema/record.go
@@ -38,16 +38,28 @@ func (r %v) Serialize(w io.Writer) error {
 `
 
 const recordStructPublicDeserializerTemplate = `
-func %v(r io.Reader) (%v, error) {
-	t := %v
-
-	deser, err := compiler.CompileSchemaBytes([]byte(t.Schema()), []byte(t.Schema()))
-        if err != nil {
-		return nil, err
-	}
-
-        err = vm.Eval(r, deser, t)
+func %[1]v(r io.Reader) (%[2]v, error) {
+	t := %[3]v
+	err := deserializeField(r, t.Schema(), t.Schema(), t)
 	return t, err
+}
+
+func %[1]vFromSchema(r io.Reader, schema string) (%[2]v, error) {
+	t := %[3]v
+	err := deserializeField(r, schema, t.Schema(), t)
+	return t, err
+}
+
+`
+
+const GENERIC_DESERIALIZER_FUNC = "deserializeField"
+const genericDeserializerTemplate = `
+func deserializeField(r io.Reader, fromSchema, toSchema string, field types.Field) error {
+	deser, err := compiler.CompileSchemaBytes([]byte(fromSchema), []byte(toSchema))
+	if err != nil {
+		return err
+	}
+	return vm.Eval(r, deser, field)
 }
 `
 
@@ -293,6 +305,14 @@ func (r *RecordDefinition) AddStruct(p *generator.Package, containers bool) erro
 
 func (r *RecordDefinition) AddSerializer(p *generator.Package) {
 	// Import guard, to avoid circular dependencies
+	if !p.HasFunction(UTIL_FILE, "", GENERIC_DESERIALIZER_FUNC) {
+		p.AddImport(UTIL_FILE, "io")
+		p.AddImport(UTIL_FILE, "github.com/actgardner/gogen-avro/vm/types")
+		p.AddImport(UTIL_FILE, "github.com/actgardner/gogen-avro/vm")
+		p.AddImport(UTIL_FILE, "github.com/actgardner/gogen-avro/compiler")
+		p.AddFunction(UTIL_FILE, "", GENERIC_DESERIALIZER_FUNC, genericDeserializerTemplate)
+	}
+
 	if !p.HasFunction(UTIL_FILE, "", r.SerializerMethod()) {
 		p.AddImport(r.filename(), "io")
 		p.AddFunction(UTIL_FILE, "", r.SerializerMethod(), r.serializerMethodDef())

--- a/schema/record.go
+++ b/schema/record.go
@@ -304,14 +304,11 @@ func (r *RecordDefinition) AddStruct(p *generator.Package, containers bool) erro
 }
 
 func (r *RecordDefinition) AddSerializer(p *generator.Package) {
-	// Import guard, to avoid circular dependencies
-	if !p.HasFunction(UTIL_FILE, "", GENERIC_DESERIALIZER_FUNC) {
-		p.AddImport(UTIL_FILE, "io")
-		p.AddImport(UTIL_FILE, "github.com/actgardner/gogen-avro/vm/types")
-		p.AddImport(UTIL_FILE, "github.com/actgardner/gogen-avro/vm")
-		p.AddImport(UTIL_FILE, "github.com/actgardner/gogen-avro/compiler")
-		p.AddFunction(UTIL_FILE, "", GENERIC_DESERIALIZER_FUNC, genericDeserializerTemplate)
-	}
+	p.AddImport(UTIL_FILE, "io")
+	p.AddImport(UTIL_FILE, "github.com/actgardner/gogen-avro/vm/types")
+	p.AddImport(UTIL_FILE, "github.com/actgardner/gogen-avro/vm")
+	p.AddImport(UTIL_FILE, "github.com/actgardner/gogen-avro/compiler")
+	p.AddFunction(UTIL_FILE, "", GENERIC_DESERIALIZER_FUNC, genericDeserializerTemplate)
 
 	if !p.HasFunction(UTIL_FILE, "", r.SerializerMethod()) {
 		p.AddImport(r.filename(), "io")

--- a/test/evolve-union/schema_test.go
+++ b/test/evolve-union/schema_test.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/actgardner/gogen-avro/compiler"
 	evolution "github.com/actgardner/gogen-avro/test/evolve-union/evolution"
-	"github.com/actgardner/gogen-avro/vm"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -21,14 +19,8 @@ func TestEvolution(t *testing.T) {
 	err := oldUnionRecord.Serialize(&buf)
 	assert.Nil(t, err)
 
-	newUnionRecord := evolution.NewUnionRecord()
-
-	deser, err := compiler.CompileSchemaBytes([]byte(oldUnionRecord.Schema()), []byte(newUnionRecord.Schema()))
+	newUnionRecord, err := evolution.DeserializeUnionRecordFromSchema(&buf, NewUnionRecord().Schema())
 	assert.Nil(t, err)
-
-	err = vm.Eval(bytes.NewReader(buf.Bytes()), deser, newUnionRecord)
-	assert.Nil(t, err)
-
 	assert.Equal(t, evolution.UnionNullStringTypeEnumString, newUnionRecord.A.UnionType)
 	assert.Equal(t, "hi", newUnionRecord.A.String)
 


### PR DESCRIPTION
This PR modifies the generated code in 'primitive.go' and record files to provide an additional deserializer function, which can use a client-supplied schema instead of always using the hard-coded one from the records.

For example, given a record named "Sample", the generated code now contains:
```
func DeserializeSample(r io.Reader) (*Sample, error) {
   ...
}

func DeserializeSampleFromSchema(r io.Reader, schema string) (*Sample, error) {
   ...
}
```
