### PR TITLE
Support both Title and Camel casing in Namers

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,6 +18,14 @@
   revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
+  branch = "master"
+  digest = "1:be3bd107094de27145a9a92e9e5e2b3eb03d3d92a5dec68da31b8eba4e4c6ae2"
+  name = "github.com/iancoleman/strcase"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "e506e3ef73653e84c592ba44aab577a46678f68c"
+
+[[projects]]
   digest = "1:dcc04c4f8d4133c33153289cbf6b329b68518579a5ed9277640eb4b502e5d02b"
   name = "github.com/linkedin/goavro"
   packages = ["."]
@@ -46,6 +54,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/golang/snappy",
+    "github.com/iancoleman/strcase",
     "github.com/linkedin/goavro",
     "github.com/stretchr/testify/assert",
   ]

--- a/generator/util.go
+++ b/generator/util.go
@@ -1,7 +1,6 @@
 package generator
 
 import (
-	"strings"
 	"unicode"
 )
 
@@ -9,17 +8,6 @@ import (
 // configured namer.
 func ToPublicName(name string) string {
 	return namer.ToPublicName(name)
-}
-
-// ToPublicSimpleName returns a go-idiomatic public name. The Avro spec
-// specifies names must start with [A-Za-z_] and contain [A-Za-z0-9_].
-// The golang spec says valid identifiers start with [A-Za-z_] and contain
-// [A-Za-z0-9], but the first character must be [A-Z] for the field to be
-// public.
-func ToPublicSimpleName(name string) string {
-	lastIndex := strings.LastIndex(name, ".")
-	name = name[lastIndex+1:]
-	return strings.Title(strings.Trim(name, "_"))
 }
 
 // ToSnake makes filenames snake-case, taken from https://gist.github.com/elwinar/14e1e897fdbe4d3432e1

--- a/gogen-avro/config.go
+++ b/gogen-avro/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"github.com/actgardner/gogen-avro/generator"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,6 +18,7 @@ const (
 	defaultContainers      = false
 	defaultShortUnions     = false
 	defaultNamespacedNames = nsNone
+	defaultNameCase        = generator.CaseTitle
 )
 
 type config struct {
@@ -24,6 +26,7 @@ type config struct {
 	containers      bool
 	shortUnions     bool
 	namespacedNames string
+	nameCase        string
 	targetDir       string
 	files           []string
 }
@@ -37,6 +40,7 @@ func parseCmdLine() config {
 	flag.BoolVar(&cfg.containers, "containers", defaultContainers, "Whether to generate container writer methods.")
 	flag.BoolVar(&cfg.shortUnions, "short-unions", defaultShortUnions, "Whether to use shorter names for Union types.")
 	flag.StringVar(&cfg.namespacedNames, "namespaced-names", defaultNamespacedNames, "Whether to generate namespaced names for types. Default is \"none\"; \"short\" uses the last part of the namespace (last word after a separator); \"full\" uses all namespace string.")
+	flag.StringVar(&cfg.nameCase, "name-case", defaultNameCase, "Case to use for generated names. Default is \"title\"; \"camel\" generates upper camel cased names.")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s [flags] <target directory> <schema files>\n\nWhere 'flags' are:\n", os.Args[0])
@@ -53,6 +57,14 @@ func parseCmdLine() config {
 	case nsNone, nsShort, nsFull:
 	default:
 		fmt.Fprintf(os.Stderr, "namespaced-names: invalid value '%s'\n\n", cfg.namespacedNames)
+		flag.Usage()
+	}
+
+	cfg.nameCase = strings.ToLower(cfg.nameCase)
+	switch cfg.nameCase {
+	case generator.CaseTitle, generator.CaseCamel:
+	default:
+		fmt.Fprintf(os.Stderr, "name-case: invalid value '%s'\n\n", cfg.nameCase)
 		flag.Usage()
 	}
 

--- a/gogen-avro/main.go
+++ b/gogen-avro/main.go
@@ -20,9 +20,11 @@ func main() {
 
 	switch cfg.namespacedNames {
 	case nsShort:
-		generator.SetNamer(generator.NewNamespaceNamer(true))
+		generator.SetNamer(generator.NewNamespaceNamer(true, cfg.nameCase))
 	case nsFull:
-		generator.SetNamer(generator.NewNamespaceNamer(false))
+		generator.SetNamer(generator.NewNamespaceNamer(false, cfg.nameCase))
+	case nsNone:
+		generator.SetNamer(generator.NewDefaultNamer(cfg.nameCase))
 	}
 
 	for _, fileName := range cfg.files {

--- a/schema/field.go
+++ b/schema/field.go
@@ -36,7 +36,7 @@ func (f *Field) Name() string {
 }
 
 func (f *Field) SimpleName() string {
-	return generator.ToPublicSimpleName(f.avroName)
+	return generator.ToPublicName(f.avroName)
 }
 
 func (f *Field) Index() int {

--- a/schema/fixed.go
+++ b/schema/fixed.go
@@ -30,7 +30,7 @@ func (s *FixedDefinition) Name() string {
 }
 
 func (s *FixedDefinition) SimpleName() string {
-	return generator.ToPublicSimpleName(s.name.Name)
+	return generator.ToPublicName(s.name.Name)
 }
 
 func (s *FixedDefinition) AvroName() QualifiedName {


### PR DESCRIPTION
Hi,

We would like to use camel cased names for our generated types.
This is a first pass at implementing that via a `name-case` flag that defaults to `title` which is equivalent to the current behaviour.

I have added some comments on the PR where I need some guidance and clarification if you would be interested in this patch.

Thanks!