### PR TITLE
Add a mechanism to allow converting from a raw string to an enum type.

### DIFF
--- a/schema/enum.go
+++ b/schema/enum.go
@@ -64,6 +64,10 @@ func (e *EnumDefinition) SerializerMethod() string {
 	return "write" + e.GoType()
 }
 
+func (e *EnumDefinition) FromStringMethod() string {
+	return "New" + e.GoType() + "Value"
+}
+
 func (e *EnumDefinition) filename() string {
 	return generator.ToSnake(e.GoType()) + ".go"
 }

--- a/schema/templates/enum.go
+++ b/schema/templates/enum.go
@@ -2,6 +2,7 @@ package templates
 
 const EnumTemplate = `
 import (
+	"fmt"
 	"io"
 
 	"github.com/actgardner/gogen-avro/vm"
@@ -30,5 +31,16 @@ func (e {{ .GoType  }}) String() string {
 
 func {{ .SerializerMethod }}(r {{ .GoType }}, w io.Writer) error {
 	return vm.WriteInt(int32(r), w)
+}
+
+func {{ .FromStringMethod }}(raw string) (r {{ .GoType }}, err error) {
+	switch raw {
+{{ range $i, $symbol := .Symbols }}
+	case {{ printf "%q" $symbol }}:
+		return {{ $.SymbolName $symbol }}, nil
+{{ end }}
+	}
+
+	return -1, fmt.Errorf("invalid value for {{ $.GoType }}: '%s'", raw)
 }
 `

--- a/test/enum/schema_test.go
+++ b/test/enum/schema_test.go
@@ -47,6 +47,10 @@ func TestEnumFixture(t *testing.T) {
 		recordVal, ok := record["EnumField"]
 		assert.Equal(t, true, ok)
 		assert.Equal(t, recordVal, f.EnumField.String())
+
+		enumified, err := NewTestEnumTypeValue(f.EnumField.String())
+		assert.Nil(t, err)
+		assert.Equal(t, f.EnumField, enumified)
 	}
 }
 
@@ -65,4 +69,10 @@ func TestRoundTrip(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, *datum, f)
 	}
+}
+
+func TestInvalidStringConversion(t *testing.T) {
+	enumified, err := NewTestEnumTypeValue("bogus")
+	assert.Error(t, err)
+	assert.Equal(t, TestEnumType(-1), enumified)
 }


### PR DESCRIPTION
Not sure returning -1 is the right thing to do here, but since defaults are associated with a field, rather than a type, this struck me as producing the most obvious / least surprising behavior when an invalid value is presented.