### PR TITLE
schema: avoid mutating objects in Definition

### DIFF
--- a/schema/array.go
+++ b/schema/array.go
@@ -39,13 +39,13 @@ func (s *ArrayField) ItemType() AvroType {
 }
 
 func (s *ArrayField) Definition(scope map[QualifiedName]interface{}) (interface{}, error) {
+	def := copyDefinition(s.definition)
 	var err error
-	s.definition["items"], err = s.itemType.Definition(scope)
+	def["items"], err = s.itemType.Definition(scope)
 	if err != nil {
 		return nil, err
 	}
-
-	return s.definition, nil
+	return def, nil
 }
 
 func (s *ArrayField) ConstructorMethod() string {

--- a/schema/definition.go
+++ b/schema/definition.go
@@ -25,3 +25,14 @@ type Definition interface {
 	IsReadableBy(f Definition) bool
 	WrapperType() string
 }
+
+func copyDefinition(x map[string]interface{}) map[string]interface{} {
+	if x == nil {
+		return x
+	}
+	x1 := make(map[string]interface{})
+	for name, val := range x {
+		x1[name] = val
+	}
+	return x1
+}

--- a/schema/field.go
+++ b/schema/field.go
@@ -101,11 +101,11 @@ func (f *Field) Type() AvroType {
 }
 
 func (f *Field) Definition(scope map[QualifiedName]interface{}) (map[string]interface{}, error) {
+	def := copyDefinition(f.definition)
 	var err error
-	f.definition["type"], err = f.avroType.Definition(scope)
+	def["type"], err = f.avroType.Definition(scope)
 	if err != nil {
 		return nil, err
 	}
-
-	return f.definition, nil
+	return def, nil
 }

--- a/schema/map.go
+++ b/schema/map.go
@@ -39,12 +39,13 @@ func (s *MapField) filename() string {
 }
 
 func (s *MapField) Definition(scope map[QualifiedName]interface{}) (interface{}, error) {
+	def := copyDefinition(s.definition)
 	var err error
-	s.definition["values"], err = s.itemType.Definition(scope)
+	def["values"], err = s.itemType.Definition(scope)
 	if err != nil {
 		return nil, err
 	}
-	return s.definition, nil
+	return def, nil
 }
 
 func (s *MapField) ConstructorMethod() string {

--- a/schema/record.go
+++ b/schema/record.go
@@ -57,6 +57,7 @@ func (r *RecordDefinition) Definition(scope map[QualifiedName]interface{}) (inte
 	if _, ok := scope[r.name]; ok {
 		return r.name.String(), nil
 	}
+	metadata := copyDefinition(r.metadata)
 	scope[r.name] = 1
 	fields := make([]map[string]interface{}, 0)
 	for _, f := range r.fields {
@@ -67,8 +68,8 @@ func (r *RecordDefinition) Definition(scope map[QualifiedName]interface{}) (inte
 		fields = append(fields, def)
 	}
 
-	r.metadata["fields"] = fields
-	return r.metadata, nil
+	metadata["fields"] = fields
+	return metadata, nil
 }
 
 func (r *RecordDefinition) ConstructorMethod() string {

--- a/schema/union.go
+++ b/schema/union.go
@@ -71,14 +71,15 @@ func (s *UnionField) ItemConstructor(f AvroType) string {
 }
 
 func (s *UnionField) Definition(scope map[QualifiedName]interface{}) (interface{}, error) {
+	def := make([]interface{}, len(s.definition))
 	var err error
 	for i, item := range s.itemType {
-		s.definition[i], err = item.Definition(scope)
+		def[i], err = item.Definition(scope)
 		if err != nil {
 			return nil, err
 		}
 	}
-	return s.definition, nil
+	return def, nil
 }
 
 func (s *UnionField) DefaultValue(lvalue string, rvalue interface{}) (string, error) {


### PR DESCRIPTION
This is an alternative to #120 to fix #119 that may be
considered preferable.

The Definition method doesn't _need_ to mutate its receiver.
Instead of doing that, which is problematic in a concurrent
scenario, copy the definition before mutating it.