### PR TITLE
Generated comment is on a single line.

### DIFF
--- a/generator/flat/templates/record.go
+++ b/generator/flat/templates/record.go
@@ -8,9 +8,7 @@ import (
 	"github.com/actgardner/gogen-avro/compiler"
 )
 
-{{ if ne .Doc "" }}
-// {{ .Doc}}
-{{ end }}  
+{{ if ne .Doc "" }}// {{ .Doc}}{{ end }}  
 type {{ .Name }} struct {
 {{ range $i, $field := .Fields }}
 	{{ if ne $field.Doc "" }}


### PR DESCRIPTION
Changed the template so that the comment is right before the struct declaration instead of having newlines before and after.
This way it fixes linting and, most important, we can use goswagger to parse the model and generate OpenAPI specs automatically through those comments.