### PR TITLE
Avro Object Container File do not need a codec specified.

### DIFF
--- a/container/reader.go
+++ b/container/reader.go
@@ -41,7 +41,8 @@ func NewReader(r io.Reader) (*Reader, error) {
 
 	codec, ok := header.Meta.M["avro.codec"]
 	if !ok {
-		return nil, fmt.Errorf("Expected avro.codec in header, not specified in metadata map - %v", header.Meta)
+		log("Expected avro.codec in header, not specified in metadata map. assuming 'null' for Codec", header.Meta)
+		codec = []byte("null")
 	}
 	log("Got OCF codec from header: %v", string(codec))
 


### PR DESCRIPTION
Avro Object Container File do not need a codec specified.
The spec says: "If codec is absent, it is assumed to be 'null'"

see https://avro.apache.org/docs/current/spec.html#Object+Container+Files