### PR TITLE
Safe-check in the serializer

### DIFF
--- a/v7/generator/flat/templates/record.go
+++ b/v7/generator/flat/templates/record.go
@@ -57,6 +57,11 @@ func Deserialize{{ .Name }}FromSchema(r io.Reader, schema string) ({{ .GoType }}
 
 func {{ .SerializerMethod }}(r {{ .GoType }}, w io.Writer) error {
 	var err error
+
+	if r == nil {
+		return nil
+	}
+	
 	{{ range $i, $field := .Fields -}}
 	err = {{ .Type.SerializerMethod }}( r.{{ .GoName }}, w)
 	if err != nil {


### PR DESCRIPTION
Added a nil check in the serializer of the record. If the record being
serialized is nil, it will bail out of the function to avoid panics.