### PR TITLE
MarshalJSON for enum generates value which can't be converted back

### DIFF
--- a/v7/generator/flat/templates/enum.go
+++ b/v7/generator/flat/templates/enum.go
@@ -45,7 +45,7 @@ func {{ .FromStringMethod }}(raw string) (r {{ .GoType }}, err error) {
 }
 
 func (b *{{ .GoType }}) MarshalJSON() ([]byte, error) {
-	return json.Marshal([]byte(b.String()))
+	return json.Marshal(b.String())
 }
 
 func (b *{{ .GoType }}) UnmarshalJSON(data []byte) (error) {

--- a/v7/test/enum/schema_test.go
+++ b/v7/test/enum/schema_test.go
@@ -76,3 +76,11 @@ func TestInvalidStringConversion(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, TestEnumType(-1), enumified)
 }
+
+func TestMarshalUnmarshal(t *testing.T) {
+	expected := EnumTestRecord{EnumField: TestEnumTypeTestSymbol3}
+	bytes, _ := json.Marshal(&expected)
+	var result EnumTestRecord
+	json.Unmarshal(bytes, &result)
+	assert.Equal(t, expected, result)
+}

--- a/v7/test/enum/test_enum_type.go
+++ b/v7/test/enum/test_enum_type.go
@@ -53,7 +53,7 @@ func NewTestEnumTypeValue(raw string) (r TestEnumType, err error) {
 }
 
 func (b *TestEnumType) MarshalJSON() ([]byte, error) {
-	return json.Marshal([]byte(b.String()))
+	return json.Marshal(b.String())
 }
 
 func (b *TestEnumType) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
MarshalJSON wouldn't generate it in a format which is used in fixtureJson. I added test which runs Marshal and Unmarshal, so we can see that both functions can work together.