### PR TITLE
Fix empty container creation

### DIFF
--- a/v10/container/writer.go
+++ b/v10/container/writer.go
@@ -120,6 +120,15 @@ func (avroWriter *Writer) WriteRecord(record AvroRecord) error {
 //  Write the current block to the file if it has been filled.  It is
 //  best-practise to always call this before the underlying io.Writer is closed.
 func (avroWriter *Writer) Flush() error {
+	// Lazily write the header if it hasn't been written yet
+	if !avroWriter.wroteHeader {
+		err := avroWriter.writeHeader(avroWriter.schema)
+		if err != nil {
+			return err
+		}
+		avroWriter.wroteHeader = true
+	}
+
 	if avroWriter.nextBlockRecords == 0 {
 		return nil
 	}


### PR DESCRIPTION
[OCF writer lazily writes header on first write instead of file open ](https://github.com/actgardner/gogen-avro/commit/135c3f743d3715f991f53d586b6259f2e12e8cf5) changed the container writer behaviour to write the header lazily on first write. Consequently, it has prevented the possibility of creating valid empty containers although the documentation of the constructor still shows:

```
//  A schema string must be passed to ensure that a correct header is written even if no records are written. This
//  is required to produce valid empty Avro container files.
```

Prior fix:

```
avro getschema /tmp/testv10.avro
log4j:WARN No appenders could be found for logger (org.apache.hadoop.metrics2.lib.MutableMetricsFactory).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Exception in thread "main" java.io.IOException: Not a data file.
        at org.apache.avro.file.DataFileStream.initialize(DataFileStream.java:102)
        at org.apache.avro.file.DataFileReader.<init>(DataFileReader.java:97)
        at org.apache.avro.tool.DataFileGetSchemaTool.run(DataFileGetSchemaTool.java:47)
        at org.apache.avro.tool.Main.run(Main.java:87)
        at org.apache.avro.tool.Main.main(Main.java:76)
Caused by: java.io.EOFException
        at org.apache.avro.io.BinaryDecoder$InputStreamByteSource.readRaw(BinaryDecoder.java:827)
        at org.apache.avro.io.BinaryDecoder.doReadBytes(BinaryDecoder.java:349)
        at org.apache.avro.io.BinaryDecoder.readFixed(BinaryDecoder.java:302)
        at org.apache.avro.io.Decoder.readFixed(Decoder.java:150)
        at org.apache.avro.file.DataFileStream.initialize(DataFileStream.java:100)
        ... 4 more
```

With fix:

```
avro getschema /tmp/testv10.avro
log4j:WARN No appenders could be found for logger (org.apache.hadoop.metrics2.lib.MutableMetricsFactory).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
{
  "type" : "record",
  "name" : "DummyRecord",
  "fields" : [ {
    "name" : "id",
    "type" : [ "null", "long" ],
    "default" : null
  }, {
    "name" : "name",
    "type" : [ "null", "string" ],
    "default" : null
  } ]
}
```