### PR TITLE
Update go mod to v1.17

### DIFF
--- a/v10/go.mod
+++ b/v10/go.mod
@@ -1,11 +1,15 @@
 module github.com/actgardner/gogen-avro/v10
 
-go 1.14
+go 1.17
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/snappy v0.0.4
 	github.com/linkedin/goavro/v2 v2.11.0
 	github.com/stretchr/testify v1.7.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )


### PR DESCRIPTION
Updates the mod version to `v1.17`. 

_Note: [The pipeline](https://github.com/actgardner/gogen-avro/blob/master/.circleci/config.yml#L7) is already running unit tests using `v1.17.2`._

How this was done:

```bash
cd v10
go mod edit -go=1.17
go mod tidy
./test.sh
# runs the following
#  go install ./cmd/...
#  go generate ./...
#  go get -t -v -u ./...
#  go test ./...
```
