### PR TITLE
fix: Deprecation of 'go get' for installing executables

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ gogen-avro has two parts: a tool which you install on your system (usually on yo
 To generate structs, install the command-line tool (this isn't necessary for the generic package):
 
 ```
-go get github.com/actgardner/gogen-avro/v10/cmd/...
+go install github.com/actgardner/gogen-avro/v10/cmd/...@latest
 ```
 
 This will put the `gogen-avro` binary in `$GOPATH/bin`, which should be part of your PATH.


### PR DESCRIPTION
'go get' is no longer supported outside a module. To build and install a command, use 'go install' with a version, like 'go install example.com/cmd@latest'. For more information, see https://golang.org/doc/go-get-install-deprecation or run 'go help get' or 'go help install'.