### PR TITLE
#193: MarshalJSON preserves avro schema ordering

### DIFF
--- a/v10/generator/flat/templates/record.go
+++ b/v10/generator/flat/templates/record.go
@@ -157,16 +157,26 @@ func (_ {{ .GoType}}) AvroCRC64Fingerprint() []byte {
 
 func (r {{ .GoType }}) MarshalJSON() ([]byte, error) {
 	var err error
+	var out, key []byte
+	out = append(out, '{')
 	output := make(map[string]json.RawMessage)
 	{{ range $i, $field := .Fields -}}
 	output[{{ printf "%q" $field.Name }}], err = json.Marshal(r.{{ $field.GoName}})
 	if err != nil {
-		return nil, err
-	}
+    	return nil, err
+    }
+	key, err = json.Marshal({{ printf "%q" $field.Name }})
+	if err != nil {
+    	return nil, err
+    }
+	out = append(out, key...)
+	out = append(out, ':')
+	out = append(out, output[{{ printf "%q" $field.Name }}]...)
+	out = append(out, ',')
 	{{ end -}}
-	return json.Marshal(output)	
+	out[len(out)-1] = '}'
+	return out, nil
 }
-
 func (r *{{ .GoType }}) UnmarshalJSON(data []byte) (error) {
 	var fields map[string]json.RawMessage
 	if err := json.Unmarshal(data, &fields); err != nil {


### PR DESCRIPTION
#193 

Since avro field order is important, and json.Marshal doesn't preserve the same ordering as struct has, I added this approach (which does generate a fair amount of code) but seems to be working.

I would add the test case for this but not sure since I am not that much into the codebase.
I did however test it locally.

And this way if we have a struct like

`
fields{
				A: "a",
				C: "c",
				D: "d",
				B: "b",
				Z: "z",
				E: "e",
			}
			`			
The order would always be after marshaling:

`{"a":"a","c":"c","d":"d","b":"b","z":"z","e":"e"}`



Edit: now to think about it maybe the template should only call json.Marshal and since it's a struct it should be fine.