### PR TITLE
fix field names conflicts

### DIFF
--- a/v10/schema/record.go
+++ b/v10/schema/record.go
@@ -74,7 +74,7 @@ func (r *RecordDefinition) Definition(scope map[QualifiedName]interface{}) (inte
 }
 
 func (r *RecordDefinition) ConstructorMethod() string {
-	return fmt.Sprintf("New%v()", r.Name())
+	return fmt.Sprintf("New%vObject()", r.Name())
 }
 
 func (r *RecordDefinition) DefaultForField(f *Field) (string, error) {


### PR DESCRIPTION
Hello! I found such case:
We have field named "foo" in our schema and gogen-avro makes constructor method named NewFoo()
Also we have field named "newFoo". After code generating we have conflict of struct NewFoo and constructor method name NewFoo() from field "foo".

I made a fix for that case