### PR TITLE
Fix build error if record has empty array of fields

### DIFF
--- a/v10/generator/flat/templates/record.go
+++ b/v10/generator/flat/templates/record.go
@@ -156,7 +156,9 @@ func (_ {{ .GoType}}) AvroCRC64Fingerprint() []byte {
 }
 
 func (r {{ .GoType }}) MarshalJSON() ([]byte, error) {
+	{{ if .Fields -}}
 	var err error
+	{{ end -}}
 	output := make(map[string]json.RawMessage)
 	{{ range $i, $field := .Fields -}}
 	output[{{ printf "%q" $field.Name }}], err = json.Marshal(r.{{ $field.GoName}})
@@ -172,8 +174,10 @@ func (r *{{ .GoType }}) UnmarshalJSON(data []byte) (error) {
 	if err := json.Unmarshal(data, &fields); err != nil {
 		return err
 	}
-
+	{{ if .Fields -}}
+	
 	var val json.RawMessage
+	{{ end -}}
 	{{ range $i, $field := .Fields -}}
 	val = func() json.RawMessage {
 		if v, ok := fields[{{ printf "%q" $field.Name }}]; ok {


### PR DESCRIPTION
Hello! I have found a corner case where an avro `record` with an empty array as `fields` will yield go code that does not build due to unused variables.

Example of avro (attention to `"fields":[ ]`):

```
{
  "type":"record",
  "name":"TestAvro",
  "fields":[
    {
      "name":"TestAvroSubType",
      "type":[
        {
          "type":"record",
          "name":"SubType_1",
          "fields":[ ]
        }
      ]
    }
  ]
}
```

When running `gogen-avro` on this `test_avro.avsc` it will output this in the file `sub_type_1.go`:

```
func (r SubType_1) MarshalJSON() ([]byte, error) {
	var err error
	output := make(map[string]json.RawMessage)
	return json.Marshal(output)
}

func (r *SubType_1) UnmarshalJSON(data []byte) error {
	var fields map[string]json.RawMessage
	if err := json.Unmarshal(data, &fields); err != nil {
		return err
	}

	var val json.RawMessage
	return nil
}
```

where the `var err error` and `var val json.RawMessage` are unused, so the build fails.

----

When running `gogen-avro` after the proposed fix, it will yield the following:

```
func (r SubType_1) MarshalJSON() ([]byte, error) {
	output := make(map[string]json.RawMessage)
	return json.Marshal(output)
}

func (r *SubType_1) UnmarshalJSON(data []byte) error {
	var fields map[string]json.RawMessage
	if err := json.Unmarshal(data, &fields); err != nil {
		return err
	}
	return nil
}
```